### PR TITLE
Flink-5538 Added Kerberos configuration support

### DIFF
--- a/container/appmaster/Dockerfile
+++ b/container/appmaster/Dockerfile
@@ -11,9 +11,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
-ENV HADOOP_CONF_DIR /etc/hadoop
-
-RUN mkdir /etc/hadoop
+ENV HADOOP_CONF_DIR /etc/hadoop/conf/
 
 ADD runit/service /var/lib/runit/service
 

--- a/container/appmaster/Dockerfile
+++ b/container/appmaster/Dockerfile
@@ -1,19 +1,46 @@
 # Includes libmesos.so
 FROM mesosphere/mesos:1.0.1-2.0.93.ubuntu1404
 
+RUN apt-get update && \
+    apt-get install -y \
+            runit \
+            curl
+
 # The base image contains java 7, but it has no environment variables set for it.
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre
+
+ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
+
+ENV HADOOP_CONF_DIR /etc/hadoop
+
+RUN mkdir /etc/hadoop
+
+ADD runit/service /var/lib/runit/service
+
+ADD runit/init.sh /sbin/init.sh
+
+RUN chmod +x /sbin/init.sh
+
+RUN ln -s /var/lib/runit/service/flink /etc/service/flink
+
+RUN chmod -R ugo+rw /etc/service
+
+RUN chmod -R ugo+rw /var/lib/
+
+RUN chmod -R ugo+rw /var/run/
+
+RUN chmod -R ugo+rw /var/log/
 
 WORKDIR /
 
 # Copy custom build to image.
 COPY flink/flink-dist/target/flink-1.2-SNAPSHOT-bin/ .
+
 # Copy base Flink configuration to image.
 COPY conf/ flink-1.2-SNAPSHOT/conf/
 
-WORKDIR flink-1.2-SNAPSHOT
-
 ENV FLINK_HOME /flink-1.2-SNAPSHOT
+
 ENV FLINK_CONF_DIR /flink-1.2-SNAPSHOT/conf
 
-CMD cd "$MESOS_SANDBOX" && "$FLINK_HOME/bin/mesos-appmaster.sh"
+WORKDIR flink-1.2-SNAPSHOT

--- a/container/appmaster/Dockerfile
+++ b/container/appmaster/Dockerfile
@@ -33,13 +33,13 @@ RUN chmod -R ugo+rw /var/log/
 WORKDIR /
 
 # Copy custom build to image.
-COPY flink/flink-dist/target/flink-1.2-SNAPSHOT-bin/ .
+COPY flink/flink-dist/target/flink-1.3-SNAPSHOT-bin/ .
 
 # Copy base Flink configuration to image.
-COPY conf/ flink-1.2-SNAPSHOT/conf/
+COPY conf/ flink-1.3-SNAPSHOT/conf/
 
-ENV FLINK_HOME /flink-1.2-SNAPSHOT
+ENV FLINK_HOME /flink-1.3-SNAPSHOT
 
-ENV FLINK_CONF_DIR /flink-1.2-SNAPSHOT/conf
+ENV FLINK_CONF_DIR /flink-1.3-SNAPSHOT/conf
 
-WORKDIR flink-1.2-SNAPSHOT
+WORKDIR flink-1.3-SNAPSHOT

--- a/container/appmaster/Dockerfile
+++ b/container/appmaster/Dockerfile
@@ -4,7 +4,8 @@ FROM mesosphere/mesos:1.0.1-2.0.93.ubuntu1404
 RUN apt-get update && \
     apt-get install -y \
             runit \
-            curl
+            curl \
+            krb5-user
 
 # The base image contains java 7, but it has no environment variables set for it.
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/jre

--- a/container/appmaster/Makefile
+++ b/container/appmaster/Makefile
@@ -7,7 +7,7 @@ build-container:
 	docker build -t $(IMAGENAME) .
 
 build-flink:
-	cd flink; mvn package -DskipTests
+	cd flink; mvn clean package -DskipTests
 
 push: build
 	docker push $(IMAGENAME)

--- a/container/appmaster/runit/init.sh
+++ b/container/appmaster/runit/init.sh
@@ -10,5 +10,27 @@ export LIBPROCESS_PORT="$PORT4"
 
 export FLINK_UI_WEB_PROXY_BASE="/service/${DCOS_SERVICE_NAME}"
 
+# validate base64 encoded keystore and truststroe
+if [[ "${FLINK_SSL_ENABLED}" == true ]]; then
+	KEYDIR=`mktemp -d`
+	trap "rm -rf $KEYDIR" EXIT
+
+	echo "${FLINK_SSL_KEYSTOREBASE64}" | base64 -d > "$KEYDIR/flink.keystore"
+	ALIAS=$(keytool -list -keystore "$KEYDIR/flink.keystore" -storepass "${FLINK_SSL_KEYSTOREPASSWORD}" | grep PrivateKeyEntry | cut -d, -f1 | head -n1)
+	if [[ -z "${ALIAS}" ]]; then
+		echo "Cannot find private key in keystore"
+		exit 1
+	fi
+
+	echo "${FLINK_SSL_TRUSTSTOREBASE64}" | base64 -d > "$KEYDIR/flink.truststore"
+	ALIAS=$(keytool -list -keystore "$KEYDIR/flink.truststore" -storepass "${FLINK_SSL_TRUSTSTOREPASSWORD}" | grep trustedCertEntry | cut -d, -f1 | head -n1)
+	if [[ -z "${ALIAS}" ]]; then
+		echo "Cannot find trusted cert entry in keystore"
+		exit 1
+	fi
+
+	rm -rf "$KEYDIR"
+fi
+
 # start service
 exec runsvdir -P /etc/service

--- a/container/appmaster/runit/init.sh
+++ b/container/appmaster/runit/init.sh
@@ -32,5 +32,13 @@ if [[ "${FLINK_SSL_ENABLED}" == true ]]; then
 	rm -rf "$KEYDIR"
 fi
 
+# Move hadoop config files, as specified by hdfs.config-url, into place.
+if [[ -f $MESOS_SANDBOX/hdfs-site.xml && -f $MESOS_SANDBOX/core-site.xml ]]; then
+		echo "Copying HDFS configuration files to ${HADOOP_CONF_DIR}"
+    mkdir -p "${HADOOP_CONF_DIR}"
+    cp $MESOS_SANDBOX/hdfs-site.xml "${HADOOP_CONF_DIR}"
+    cp $MESOS_SANDBOX/core-site.xml "${HADOOP_CONF_DIR}"
+fi
+
 # start service
 exec runsvdir -P /etc/service

--- a/container/appmaster/runit/init.sh
+++ b/container/appmaster/runit/init.sh
@@ -40,5 +40,10 @@ if [[ -f $MESOS_SANDBOX/hdfs-site.xml && -f $MESOS_SANDBOX/core-site.xml ]]; the
     cp $MESOS_SANDBOX/core-site.xml "${HADOOP_CONF_DIR}"
 fi
 
+# Move kerberos config file, as specified by security.kerberos.krb5conf, into place.
+if [[ "${FLINK_SECURITY_KRB5_CONF_BASE64}" != "" ]]; then
+    echo "${FLINK_SECURITY_KRB5_CONF_BASE64}" | base64 -d > /etc/krb5.conf
+fi
+
 # start service
 exec runsvdir -P /etc/service

--- a/container/appmaster/runit/init.sh
+++ b/container/appmaster/runit/init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+export FLINK_JOBMANAGER_WEB_PORT="$PORT0"
+export FLINK_JOBMANAGER_RPC_PORT="$PORT1"
+export FLINK_BLOB_SERVER_PORT="$PORT2"
+export FLINK_MESOS_ARTIFACT_SERVER_PORT="$PORT3"
+export LIBPROCESS_PORT="$PORT4"
+
+export FLINK_UI_WEB_PROXY_BASE="/service/${DCOS_SERVICE_NAME}"
+
+# start service
+exec runsvdir -P /etc/service

--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -4,7 +4,11 @@ set -x
 
 exec 2>&1
 
-function export_flink_config_opts() {
+FLINK_SECURITY_DIR=/etc/security/flink
+mkdir -p $FLINK_SECURITY_DIR
+export APPLICATION_WEB_PROXY_BASE="${FLINK_UI_WEB_PROXY_BASE}"
+
+function add_flink_configurations() {
     export FLINK_JAVA_OPTS=""
     export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dblob.server.port=$FLINK_BLOB_SERVER_PORT"
     export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Djobmanager.heap.mb=$FLINK_APP_MASTER_HEAP"
@@ -36,39 +40,49 @@ function add_mesos_configurations() {
 }
 
 function add_ssl_configurations() {
-  FLINK_SECURITY_DIR=/etc/security/flink
-  mkdir -p $FLINK_SECURITY_DIR
+  if [[ "${FLINK_SSL_ENABLED}" == true ]]; then
+    if [ "${FLINK_SSL_KEYSTOREBASE64}" != "" ]; then
+        echo "${FLINK_SSL_KEYSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-keystore.jks
+        add_if_non_empty security.ssl.keystore $FLINK_SECURITY_DIR/flink-keystore.jks
+    fi
 
-  if [ "${FLINK_SSL_KEYSTOREBASE64}" != "" ]; then
-      echo "${FLINK_SSL_KEYSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-keystore.jks
-      add_if_non_empty security.ssl.keystore $FLINK_SECURITY_DIR/flink-keystore.jks
+    if [ "${FLINK_SSL_TRUSTSTOREBASE64}" != "" ]; then
+        echo "${FLINK_SSL_TRUSTSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-truststore.jks
+        add_if_non_empty security.ssl.truststore $FLINK_SECURITY_DIR/flink-truststore.jks
+    fi
+
+    add_if_non_empty security.ssl.enabled "${FLINK_SSL_ENABLED}"
+    add_if_non_empty security.ssl.key-password "${FLINK_SSL_KEYPASSWORD}"
+    add_if_non_empty security.ssl.keystore-password "${FLINK_SSL_KEYSTOREPASSWORD}"
+    add_if_non_empty security.ssl.truststore-password "${FLINK_SSL_TRUSTSTOREPASSWORD}"
+    add_if_non_empty security.ssl.protocol "${FLINK_SSL_PROTOCOL}"
+    add_if_non_empty security.ssl.algorithms "${FLINK_SSL_ENABLEDALGORITHMS}"
+    add_if_non_empty mesos.resourcemanager.artifactserver.ssl.enabled "${FLINK_ARTIFACT_SERVER_SSL_ENABLED}"
   fi
-
-  if [ "${FLINK_SSL_TRUSTSTOREBASE64}" != "" ]; then
-      echo "${FLINK_SSL_TRUSTSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-truststore.jks
-      add_if_non_empty security.ssl.truststore $FLINK_SECURITY_DIR/flink-truststore.jks
-  fi
-
-  add_if_non_empty security.ssl.enabled "${FLINK_SSL_ENABLED}"
-  add_if_non_empty security.ssl.key-password "${FLINK_SSL_KEYPASSWORD}"
-  add_if_non_empty security.ssl.keystore-password "${FLINK_SSL_KEYSTOREPASSWORD}"
-  add_if_non_empty security.ssl.truststore-password "${FLINK_SSL_TRUSTSTOREPASSWORD}"
-  add_if_non_empty security.ssl.protocol "${FLINK_SSL_PROTOCOL}"
-  add_if_non_empty security.ssl.algorithms "${FLINK_SSL_ENABLEDALGORITHMS}"
-  add_if_non_empty mesos.resourcemanager.artifactserver.ssl.enabled "${FLINK_ARTIFACT_SERVER_SSL_ENABLED}"
 }
 
-export APPLICATION_WEB_PROXY_BASE="${FLINK_UI_WEB_PROXY_BASE}"
+function add_kerberos_configurations() {
+  add_if_non_empty security.kerberos.login.use-ticket-cache "${FLINK_SECURITY_USE_TICKET_CACHE}"
+  if [ "${FLINK_SECURITY_KEYTAB_BASE64}" != "" ]; then
+      echo "${FLINK_SECURITY_KEYTAB_BASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-service.keytab
+      add_if_non_empty security.kerberos.login.keytab $FLINK_SECURITY_DIR/flink-service.keytab
+  fi
+  add_if_non_empty security.kerberos.login.principal "${FLINK_SECURITY_PRINCIPAL}"
+  if [[ "${FLINK_SECURITY_KRB5_CONF_BASE64}" != "" ]]; then
+    export JVM_ARGS="$JVM_ARGS -Djava.security.krb5.conf=/etc/krb5.conf"
+  fi
+}
 
-export_flink_config_opts
+function update_log_level() {
+  if [[ "${FLINK_LOG_LEVEL}" != "" ]]; then
+    sed -ie 's/log4j.rootLogger=INFO, file/log4j.rootLogger='"${FLINK_LOG_LEVEL}"', file/g' ${FLINK_HOME}/conf/log4j.properties
+  fi
+}
+
+add_flink_configurations
 add_mesos_configurations
-
-if [[ "${FLINK_SSL_ENABLED}" == true ]]; then
-  add_ssl_configurations
-fi
-
-if [[ "${FLINK_LOG_LEVEL}" != "" ]]; then
-  sed -ie 's/log4j.rootLogger=INFO, file/log4j.rootLogger='"${FLINK_LOG_LEVEL}"', file/g' ${FLINK_HOME}/conf/log4j.properties
-fi
+add_ssl_configurations
+add_kerberos_configurations
+update_log_level
 
 exec ${FLINK_HOME}/bin/mesos-appmaster.sh ${FLINK_JAVA_OPTS}

--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+set -x
+
+exec 2>&1
+
+function export_flink_config_opts() {
+    export FLINK_JAVA_OPTS=""
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dblob.server.port=$FLINK_BLOB_SERVER_PORT"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Djobmanager.heap.mb=$FLINK_APP_MASTER_HEAP"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Djobmanager.rpc.port=$FLINK_JOBMANAGER_RPC_PORT"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Djobmanager.web.port=$FLINK_JOBMANAGER_WEB_PORT"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dmesos.artifact-server.port=$FLINK_MESOS_ARTIFACT_SERVER_PORT"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dmesos.initial-tasks=$FLINK_TASK_MANAGER_COUNT"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dmesos.resourcemanager.tasks.cpus=$FLINK_TASK_MANAGER_CPUS"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dmesos.resourcemanager.tasks.mem=$FLINK_TASK_MANAGER_MEM"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dtaskmanager.heap.mb=$FLINK_TASK_MANAGER_HEAP"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dtaskmanager.memory.preallocate=$FLINK_TASK_MANAGER_MEM_PREALLOCATION"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dtaskmanager.numberOfTaskSlots=$FLINK_TASK_SLOTS"
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dparallelism.default=$FLINK_PARALLELISM_DEFAULT"
+}
+
+export APPLICATION_WEB_PROXY_BASE="${FLINK_UI_WEB_PROXY_BASE}"
+
+export_flink_config_opts
+
+exec ${FLINK_HOME}/bin/mesos-appmaster.sh ${FLINK_JAVA_OPTS}

--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -18,10 +18,57 @@ function export_flink_config_opts() {
     export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dtaskmanager.memory.preallocate=$FLINK_TASK_MANAGER_MEM_PREALLOCATION"
     export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dtaskmanager.numberOfTaskSlots=$FLINK_TASK_SLOTS"
     export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dparallelism.default=$FLINK_PARALLELISM_DEFAULT"
+    if [ "${FLINK_EXTRA_ARGS}" != "" ]; then
+      export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS $FLINK_EXTRA_ARGS"
+    fi
+}
+
+function add_if_non_empty() {
+	if [ -n "$2" ]; then
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -D$1=$2"
+	fi
+}
+
+function add_mesos_configurations() {
+  add_if_non_empty mesos.resourcemanager.framework.role "${FLINK_DISPATCHER_MESOS_ROLE}"
+  add_if_non_empty mesos.resourcemanager.framework.principal "${FLINK_DISPATCHER_MESOS_PRINCIPAL}"
+  add_if_non_empty mesos.resourcemanager.framework.secret "${FLINK_DISPATCHER_MESOS_SECRET}"
+}
+
+function add_ssl_configurations() {
+  FLINK_SECURITY_DIR=/etc/security/flink
+  mkdir -p $FLINK_SECURITY_DIR
+
+  if [ "${FLINK_SSL_KEYSTOREBASE64}" != "" ]; then
+      echo "${FLINK_SSL_KEYSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-keystore.jks
+      add_if_non_empty security.ssl.keystore $FLINK_SECURITY_DIR/flink-keystore.jks
+  fi
+
+  if [ "${FLINK_SSL_TRUSTSTOREBASE64}" != "" ]; then
+      echo "${FLINK_SSL_TRUSTSTOREBASE64}" | base64 -d > $FLINK_SECURITY_DIR/flink-truststore.jks
+      add_if_non_empty security.ssl.truststore $FLINK_SECURITY_DIR/flink-truststore.jks
+  fi
+
+  add_if_non_empty security.ssl.enabled "${FLINK_SSL_ENABLED}"
+  add_if_non_empty security.ssl.key-password "${FLINK_SSL_KEYPASSWORD}"
+  add_if_non_empty security.ssl.keystore-password "${FLINK_SSL_KEYSTOREPASSWORD}"
+  add_if_non_empty security.ssl.truststore-password "${FLINK_SSL_TRUSTSTOREPASSWORD}"
+  add_if_non_empty security.ssl.protocol "${FLINK_SSL_PROTOCOL}"
+  add_if_non_empty security.ssl.algorithms "${FLINK_SSL_ENABLEDALGORITHMS}"
+  add_if_non_empty mesos.resourcemanager.artifactserver.ssl.enabled "${FLINK_ARTIFACT_SERVER_SSL_ENABLED}"
 }
 
 export APPLICATION_WEB_PROXY_BASE="${FLINK_UI_WEB_PROXY_BASE}"
 
 export_flink_config_opts
+add_mesos_configurations
+
+if [[ "${FLINK_SSL_ENABLED}" == true ]]; then
+  add_ssl_configurations
+fi
+
+if [[ "${FLINK_LOG_LEVEL}" != "" ]]; then
+  sed -ie 's/log4j.rootLogger=INFO, file/log4j.rootLogger='"${FLINK_LOG_LEVEL}"', file/g' ${FLINK_HOME}/conf/log4j.properties
+fi
 
 exec ${FLINK_HOME}/bin/mesos-appmaster.sh ${FLINK_JAVA_OPTS}

--- a/service/config.json
+++ b/service/config.json
@@ -21,7 +21,32 @@
           "type": "integer",
           "default": 1,
           "minimum": 1
-        }
+        },
+        "role":{
+           "description":"The Dispatcher component will register with Mesos with this role.",
+           "type":"string",
+           "default":"*"
+        },
+        "principal":{
+           "description":"The Dispatcher component will register with Mesos with this principal.",
+           "type":"string",
+           "default":""
+        },
+        "secret":{
+           "description":"The Dispatcher component will register with mesos with this secret.",
+           "type":"string",
+           "default":""
+        },
+        "user":{
+           "description":"Tasks will run as this user.",
+           "type":"string",
+           "default":"root"
+        },
+        "log-level":{
+           "type":"string",
+           "description":"log4j log level for Flink cluster.  May be set to any valid log4j log level: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html",
+           "default":"INFO"
+        }        
       }
     },
 

--- a/service/config.json
+++ b/service/config.json
@@ -167,6 +167,17 @@
           }
         }
       }
+    },
+
+    "hdfs": {
+      "description": "Flink Hadoop configuration properties",
+      "type": "object",
+      "properties": {
+        "config-url": {
+          "type": "string",
+          "description": "Base URL that serves HDFS config files (hdfs-site.xml, core-site.xml)."
+        }
+      }
     }
 
   }

--- a/service/config.json
+++ b/service/config.json
@@ -46,7 +46,12 @@
            "type":"string",
            "description":"log4j log level for Flink cluster.  May be set to any valid log4j log level: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html",
            "default":"INFO"
-        }        
+        },
+        "extra-args":{
+           "description":"Use -D<KEY>=<VALUE> format to provide any additional Flink configuration options.",
+           "type":"string",
+           "default":""
+        }
       }
     },
 
@@ -109,6 +114,60 @@
           "default": true
         }
       }
+    },
+
+    "security":{
+      "description":"Flink security configuration properties",
+      "type":"object",
+      "properties":{
+        "ssl":{
+          "description":"Flink SSL certificates and private key configuration.",
+          "type":"object",
+          "properties":{
+            "enabled":{
+              "default":false,
+              "description":"Set to true to enable SSL.",
+              "type":"boolean"
+            },
+            "keyStoreBase64":{
+              "default":"",
+              "description":"Base64 encoded blob containing a Java keystore.",
+              "type":"string"
+            },
+            "trustStoreBase64":{
+              "default":"",
+              "description":"Base64 encoded blob containing a Java truststore.",
+              "type":"string"
+            },
+            "keyPassword":{
+              "default":"",
+              "description":"An optional password for the private key in the keystore.",
+              "type":"string"
+            },
+            "keyStorePassword":{
+              "default":"",
+              "description":"An optional password for the keystore (and the key if keyPassword is not given).",
+              "type":"string"
+            },
+            "trustStorePassword":{
+              "default":"",
+              "description":"An optional password for the truststore.",
+              "type":"string"
+            },
+            "enabledAlgorithms":{
+              "default":"TLS_RSA_WITH_AES_128_CBC_SHA",
+              "description":"A comma-separared list of allowed ciphers.",
+              "type":"string"
+            },
+            "enableArtifactServerSSL":{
+              "default":false,
+              "description":"Set to true to enable SSL for Artifact server.",
+              "type":"boolean"
+            }
+          }
+        }
+      }
     }
+
   }
 }

--- a/service/config.json
+++ b/service/config.json
@@ -120,6 +120,32 @@
       "description":"Flink security configuration properties",
       "type":"object",
       "properties":{
+        "kerberos": {
+          "description": "Flink Kerberos configuration.",
+          "type": "object",
+          "properties": {
+            "krb5conf": {
+              "description": "Base64 encoded krb5.conf file.  Copied to JMs and TMs so that they may access your KDC.",
+              "type": "string",
+              "default": ""
+            },
+            "use-ticket-cache":{
+              "description":"Indicates whether to read from the user's kerberos ticket cache.",
+              "type":"boolean",
+              "default":true
+            },
+            "keytab":{
+              "description":"Base64 encoded keytab file. Flink cluster and job will run under this identity.",
+              "type":"string",
+              "default":""
+            },
+            "principal":{
+              "description":"Kerberos principal name associated with the keytab.",
+              "type":"string",
+              "default":""
+            }
+          }
+        },
         "ssl":{
           "description":"Flink SSL certificates and private key configuration.",
           "type":"object",

--- a/service/marathon.json.mustache
+++ b/service/marathon.json.mustache
@@ -72,9 +72,9 @@
   ],
 
   "labels": {
-{{#service.user}}
-    "user": "{{service.user}}",
-{{/service.user}}
+{{#hdfs.config-url}}
+    "FLINK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
+{{/hdfs.config-url}}
 {{#security.ssl.enabled}}
     "DCOS_SERVICE_SCHEME": "https",
 {{/security.ssl.enabled}}
@@ -83,6 +83,15 @@
 {{/security.ssl.enabled}}
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_PORT_INDEX": "0"
-  }
+  },
+{{#service.user}}
+  "user": "{{service.user}}",
+{{/service.user}}
+  "uris": [
+{{#hdfs.config-url}}
+  "{{hdfs.config-url}}/hdfs-site.xml",
+  "{{hdfs.config-url}}/core-site.xml"
+{{/hdfs.config-url}}
+  ]
 
 }

--- a/service/marathon.json.mustache
+++ b/service/marathon.json.mustache
@@ -5,6 +5,17 @@
   "cmd": "/sbin/init.sh",
 
   "env": {
+{{#security.ssl.enabled}}
+    "FLINK_SSL_ENABLED": "{{security.ssl.enabled}}",
+    "FLINK_SSL_KEYSTOREBASE64": "{{security.ssl.keyStoreBase64}}",
+    "FLINK_SSL_TRUSTSTOREBASE64": "{{security.ssl.trustStoreBase64}}",
+    "FLINK_SSL_KEYSTOREPASSWORD": "{{security.ssl.keyStorePassword}}",
+    "FLINK_SSL_KEYPASSWORD": "{{security.ssl.keyPassword}}",
+    "FLINK_SSL_TRUSTSTOREPASSWORD": "{{security.ssl.keyStorePassword}}",
+    "FLINK_SSL_PROTOCOL": "{{security.ssl.protocol}}",
+    "FLINK_SSL_ENABLEDALGORITHMS": "{{security.ssl.enabledAlgorithms}}",
+    "FLINK_ARTIFACT_SERVER_SSL_ENABLED": "{{security.ssl.enableArtifactServerSSL}}",
+{{/security.ssl.enabled}}
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "FLINK_TASK_SLOTS": "{{service.slots}}",
     "FLINK_PARALLELISM_DEFAULT": "{{service.parallelism-default}}",
@@ -13,6 +24,7 @@
     "FLINK_DISPATCHER_MESOS_SECRET": "{{service.secret}}",
     "FLINK_USER": "{{service.user}}",
     "FLINK_LOG_LEVEL": "{{service.log-level}}",
+    "FLINK_EXTRA_ARGS": "{{service.extra-args}}",
     "FLINK_APP_MASTER_CPUS": "{{app-master.cpus}}",
     "FLINK_APP_MASTER_MEM": "{{app-master.memory}}",
     "FLINK_APP_MASTER_HEAP": "{{app-master.heap}}",
@@ -39,14 +51,19 @@
       "forcePullImage": true
     }
   },
-
   "ports": [0, 0, 0, 0, 0],
 
   "healthChecks": [
     {
+{{#security.ssl.enabled}}
+      "protocol": "COMMAND",
+      "command": { "value": "curl -f -k https://$HOST:$PORT0/" },
+{{/security.ssl.enabled}}
+{{^security.ssl.enabled}}
       "protocol": "HTTP",
       "path": "/",
       "portIndex": 0,
+{{/security.ssl.enabled}}
       "gracePeriodSeconds": 5,
       "intervalSeconds": 60,
       "timeoutSeconds": 10,
@@ -58,8 +75,14 @@
 {{#service.user}}
     "user": "{{service.user}}",
 {{/service.user}}
+{{#security.ssl.enabled}}
+    "DCOS_SERVICE_SCHEME": "https",
+{{/security.ssl.enabled}}
+{{^security.ssl.enabled}}
+    "DCOS_SERVICE_SCHEME": "http",
+{{/security.ssl.enabled}}
     "DCOS_SERVICE_NAME": "{{service.name}}",
-    "DCOS_SERVICE_PORT_INDEX": "0",
-    "DCOS_SERVICE_SCHEME": "http"
+    "DCOS_SERVICE_PORT_INDEX": "0"
   }
+
 }

--- a/service/marathon.json.mustache
+++ b/service/marathon.json.mustache
@@ -16,6 +16,21 @@
     "FLINK_SSL_ENABLEDALGORITHMS": "{{security.ssl.enabledAlgorithms}}",
     "FLINK_ARTIFACT_SERVER_SSL_ENABLED": "{{security.ssl.enableArtifactServerSSL}}",
 {{/security.ssl.enabled}}
+{{#security.kerberos.krb5conf}}
+    "FLINK_SECURITY_KRB5_CONF_BASE64": "{{security.kerberos.krb5conf}}",
+{{/security.kerberos.krb5conf}}
+
+{{#security.kerberos.use-ticket-cache}}
+    "FLINK_SECURITY_USE_TICKET_CACHE": "{{security.kerberos.use-ticket-cache}}",
+{{/security.kerberos.use-ticket-cache}}
+
+{{#security.kerberos.keytab}}
+    "FLINK_SECURITY_KEYTAB_BASE64": "{{security.kerberos.keytab}}",
+{{/security.kerberos.keytab}}
+
+{{#security.kerberos.principal}}
+    "FLINK_SECURITY_PRINCIPAL": "{{security.kerberos.principal}}",
+{{/security.kerberos.principal}}
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "FLINK_TASK_SLOTS": "{{service.slots}}",
     "FLINK_PARALLELISM_DEFAULT": "{{service.parallelism-default}}",

--- a/service/marathon.json.mustache
+++ b/service/marathon.json.mustache
@@ -2,18 +2,41 @@
   "id": "{{service.name}}",
   "cpus": {{app-master.cpus}},
   "mem": {{app-master.memory}},
+  "cmd": "/sbin/init.sh",
 
   "env": {
-    "DCOS_SERVICE_NAME": "{{service.name}}"
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "FLINK_TASK_SLOTS": "{{service.slots}}",
+    "FLINK_PARALLELISM_DEFAULT": "{{service.parallelism-default}}",
+    "FLINK_DISPATCHER_MESOS_ROLE": "{{service.role}}",
+    "FLINK_DISPATCHER_MESOS_PRINCIPAL": "{{service.principal}}",
+    "FLINK_DISPATCHER_MESOS_SECRET": "{{service.secret}}",
+    "FLINK_USER": "{{service.user}}",
+    "FLINK_LOG_LEVEL": "{{service.log-level}}",
+    "FLINK_APP_MASTER_CPUS": "{{app-master.cpus}}",
+    "FLINK_APP_MASTER_MEM": "{{app-master.memory}}",
+    "FLINK_APP_MASTER_HEAP": "{{app-master.heap}}",
+    "FLINK_TASK_MANAGER_COUNT": "{{task-managers.count}}",
+    "FLINK_TASK_MANAGER_CPUS": "{{task-managers.cpus}}",
+    "FLINK_TASK_MANAGER_MEM": "{{task-managers.memory}}",
+    "FLINK_TASK_MANAGER_HEAP": "{{task-managers.heap}}",
+    "FLINK_TASK_MANAGER_MEM_PREALLOCATION": "{{task-managers.memory-preallocation}}"
   },
-
-  "cmd": "export LIBPROCESS_PORT=$PORT4 && cd \"$MESOS_SANDBOX\" && \"$FLINK_HOME/bin/mesos-appmaster.sh\" -Dblob.server.port=$PORT2 -Djobmanager.heap.mb={{app-master.heap}} -Djobmanager.rpc.port=$PORT1 -Djobmanager.web.port=$PORT0 -Dmesos.artifact-server.port=$PORT3 -Dmesos.initial-tasks={{task-managers.count}} -Dmesos.resourcemanager.tasks.cpus={{task-managers.cpus}} -Dmesos.resourcemanager.tasks.mem={{task-managers.memory}} -Dtaskmanager.heap.mb={{task-managers.heap}} -Dtaskmanager.memory.preallocate={{task-managers.memory-preallocation}} -Dtaskmanager.numberOfTaskSlots={{service.slots}} -Dparallelism.default={{service.parallelism-default}}",
 
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "{{resource.assets.container.docker.flink}}",
-      "network": "HOST"
+      "network": "HOST",
+{{#service.user}}
+      "parameters": [
+        {
+          "key": "user",
+          "value": "{{service.user}}"
+        }
+      ],
+{{/service.user}}
+      "forcePullImage": true
     }
   },
 
@@ -32,6 +55,9 @@
   ],
 
   "labels": {
+{{#service.user}}
+    "user": "{{service.user}}",
+{{/service.user}}
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"


### PR DESCRIPTION
This PR addresses the issue https://issues.apache.org/jira/browse/FLINK-5538

- KRB5 configuration and keytab file can be supplied as base64 encoded value
- Added Kerberos client to base docker image
- Validated and tested with secure/insecure Hadoop

