### PR TITLE
build both 2.10 and 2.11 images

### DIFF
--- a/container/appmaster/Makefile
+++ b/container/appmaster/Makefile
@@ -1,13 +1,21 @@
-IMAGENAME = dcos-flink:1.2.0-rc0
+IMAGENAME = dcos-flink:1.2.0-1.4
+IMAGENAME_2_11 = dcos-flink-2-11:1.2.0-1.4
 
 
-build: build-flink build-container
+build: build-flink build-container build-flink-2-11 build-container-2-11
 
 build-container:
 	docker build -t $(IMAGENAME) .
 
+build-container-2-11:
+	docker build -t $(IMAGENAME_2_11) .
+
+build-flink-2-11:
+	cd flink; ./tools/change-scala-version.sh 2.11; mvn clean package -DskipTests
+
 build-flink:
-	cd flink; mvn clean package -DskipTests
+	cd flink; ./tools/change-scala-version.sh 2.10; mvn clean package -DskipTests
 
 push: build
 	docker push $(IMAGENAME)
+	docker push $(IMAGENAME_2_11)

--- a/service/config.json
+++ b/service/config.json
@@ -51,6 +51,11 @@
            "description":"Use -D<KEY>=<VALUE> format to provide any additional Flink configuration options.",
            "type":"string",
            "default":""
+        },
+        "scala-2-11": {
+          "description":"Use flink compiled for scala-2.11 rather than the default scala-2.10",
+          "type":"boolean",
+          "default":false
         }
       }
     },

--- a/service/marathon.json.mustache
+++ b/service/marathon.json.mustache
@@ -53,7 +53,12 @@
   "container": {
     "type": "DOCKER",
     "docker": {
+{{#scala-2-11}}
+      "image": "{{resource.assets.container.docker.flink-2-11}}",
+{{/scala-2-11}}
+{{^scala-2-11}}
       "image": "{{resource.assets.container.docker.flink}}",
+{{/scala-2-11
       "network": "HOST",
 {{#service.user}}
       "parameters": [

--- a/service/resource.json
+++ b/service/resource.json
@@ -2,7 +2,8 @@
   "assets": {
     "container": {
       "docker": {
-        "flink": "mesosphere/dcos-flink:1.2.0-1.0"
+        "flink": "mesosphere/dcos-flink:1.2.0-1.4",
+        "flink-2-11": "mesosphere/dcos-flink-2-11:1.2.0-1.4"
       }
     }
   },


### PR DESCRIPTION
Fixes #19.

This allows for building both scala 2.10 and scala 2.11 images.

It should be pretty straight forward to also apply this into universe repo, but want to land it here first.

I am not totally sure how to test this end to end, but the docker images to succeed to build