### PR TITLE
Add HA configuration

### DIFF
--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -73,6 +73,29 @@ function add_kerberos_configurations() {
   fi
 }
 
+function add_ha_configurations() {
+  if [[ "${FLINK_HA_ENABLED}" == true ]]; then
+    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dhigh-availability=ZOOKEEPER"
+    add_if_non_empty high-availability.cluster-id "${FLINK_HIGH_AVAILABILITY_CLUSTER_ID}"
+    add_if_non_empty high-availability.storageDir "${FLINK_HIGH_AVAILABILITY_STORAGE_DIR}"
+    add_if_non_empty high-availability.zookeeper.quorum "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_QUORUM}"
+    add_if_non_empty high-availability.jobmanager.port "${FLINK_HIGH_AVAILABILITY_JOBMANAGER_PORT}"
+    add_if_non_empty high-availability.job.delay "${FLINK_HIGH_AVAILABILITY_JOB_DELAY}"
+    add_if_non_empty high-availability.zookeeper.path.root "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_ROOT}"
+    # used for the client at ha services initiated by the mesos app master runner
+    add_if_non_empty ghigh-availability.zookeeper.client.session-timeout \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_SESSION_TIMEOUT}"
+    add_if_non_empty high-availability.zookeeper.client.connection-timeout \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_CONNECTION_TIMEOUT}"
+    add_if_non_empty high-availability.zookeeper.client.retry-wait \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_RETRY_WAIT}"
+    add_if_non_empty high-availability.zookeeper.client.max-retry-attempts \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_MAX_RETRY_ATTEMPTS}"
+    add_if_non_empty high-availability.zookeeper.path.running-registry \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_RUNNING_REGISTRY}"
+  fi
+}
+
 function update_log_level() {
   if [[ "${FLINK_LOG_LEVEL}" != "" ]]; then
     sed -ie 's/log4j.rootLogger=INFO, file/log4j.rootLogger='"${FLINK_LOG_LEVEL}"', file/g' ${FLINK_HOME}/conf/log4j.properties
@@ -80,6 +103,7 @@ function update_log_level() {
 }
 
 add_flink_configurations
+add_ha_configurations
 add_mesos_configurations
 add_ssl_configurations
 add_kerberos_configurations

--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -33,8 +33,14 @@ function add_if_non_empty() {
 	fi
 }
 
+function add_if_non_empty_to_config() {
+	if [ -n "$2" ]; then
+     echo "$1: $2" >> ${FLINK_HOME}/conf/flink-conf.yaml
+	fi
+}
+
 function add_mesos_configurations() {
-  add_if_non_empty jobmanager.rpc.address $(hostname -f)       
+  add_if_non_empty jobmanager.rpc.address $(hostname -f)
   add_if_non_empty mesos.resourcemanager.framework.role "${FLINK_DISPATCHER_MESOS_ROLE}"
   add_if_non_empty mesos.resourcemanager.framework.principal "${FLINK_DISPATCHER_MESOS_PRINCIPAL}"
   add_if_non_empty mesos.resourcemanager.framework.secret "${FLINK_DISPATCHER_MESOS_SECRET}"
@@ -76,24 +82,33 @@ function add_kerberos_configurations() {
 
 function add_ha_configurations() {
   if [[ "${FLINK_HA_ENABLED}" == true ]]; then
-    export FLINK_JAVA_OPTS="$FLINK_JAVA_OPTS -Dhigh-availability=ZOOKEEPER"
-    add_if_non_empty high-availability.cluster-id "${FLINK_HIGH_AVAILABILITY_CLUSTER_ID}"
-    add_if_non_empty high-availability.storageDir "${FLINK_HIGH_AVAILABILITY_STORAGE_DIR}"
-    add_if_non_empty high-availability.zookeeper.quorum "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_QUORUM}"
-    add_if_non_empty high-availability.jobmanager.port "${FLINK_HIGH_AVAILABILITY_JOBMANAGER_PORT}"
-    add_if_non_empty high-availability.job.delay "${FLINK_HIGH_AVAILABILITY_JOB_DELAY}"
-    add_if_non_empty high-availability.zookeeper.path.root "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_ROOT}"
-    # used for the client at ha services initiated by the mesos app master runner
-    add_if_non_empty ghigh-availability.zookeeper.client.session-timeout \
-    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_SESSION_TIMEOUT}"
-    add_if_non_empty high-availability.zookeeper.client.connection-timeout \
-    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_CONNECTION_TIMEOUT}"
-    add_if_non_empty high-availability.zookeeper.client.retry-wait \
-    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_RETRY_WAIT}"
-    add_if_non_empty high-availability.zookeeper.client.max-retry-attempts \
-    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_MAX_RETRY_ATTEMPTS}"
-    add_if_non_empty high-availability.zookeeper.path.running-registry \
+    add_if_non_empty_to_config high-availability ZOOKEEPER
+    add_if_non_empty_to_config high-availability.cluster-id "${FLINK_HIGH_AVAILABILITY_CLUSTER_ID}"
+    add_if_non_empty_to_config high-availability.storageDir "${FLINK_HIGH_AVAILABILITY_STORAGE_DIR}"
+    add_if_non_empty_to_config high-availability.zookeeper.quorum "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_QUORUM}"
+    add_if_non_empty_to_config high-availability.jobmanager.port "${FLINK_HIGH_AVAILABILITY_JOBMANAGER_PORT}"
+    add_if_non_empty_to_config high-availability.job.delay "${FLINK_HIGH_AVAILABILITY_JOB_DELAY}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.root "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_ROOT}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.running-registry \
     "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_RUNNING_REGISTRY}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.latch "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_LEADER_LATCH}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.jobgraphs "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_JOBGRAPHS}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.leader "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_LEADER}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.checkpoints "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_CHECKPOINTS}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.checkpoint-counter "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_CHECKPOINT_COUNTER}"
+    add_if_non_empty_to_config high-availability.zookeeper.path.mesos-workers "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_PATH_MESOS_WORKERS}"
+
+    # used for the client at ha services initiated by the mesos app master runner
+    add_if_non_empty_to_config high-availability.zookeeper.client.session-timeout \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_SESSION_TIMEOUT}"
+    add_if_non_empty_to_config high-availability.zookeeper.client.connection-timeout \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_CONNECTION_TIMEOUT}"
+    add_if_non_empty_to_config high-availability.zookeeper.client.retry-wait \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_RETRY_WAIT}"
+    add_if_non_empty_to_config high-availability.zookeeper.client.max-retry-attempts \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_MAX_RETRY_ATTEMPTS}"
+    add_if_non_empty_to_config high-availability.zookeeper.client.acl \
+    "${FLINK_HIGH_AVAILABILITY_ZOOKEEPER_CLIENT_ACL}"
   fi
 }
 


### PR DESCRIPTION
Fixes #7, relates to https://github.com/mesosphere/universe/pull/1163

The mesosphere image needs to be built and pushed. Don't have access.
Assumes hdfs is there for the default case (any proper setup should have HA enabled by default) and the storage dir (hdfs://hdfs/flink/recovery) to have been created.
In order to create the dir you need to download the appropriate hdfs distro within your dcos cluster and
execute: 
`dcos hdfs endpoints core-site.xml`
`dcos hdfs endpoints hdfs-site.xml`

to download the required files, to override the defaults within the distro so that finally you can issue commands like:
`hadoop fs -mkdir -p ...`

In order to test it after you build the image under your own account, launch flink with HA, use the following command within a docker container of the flink docker image:

`./bin/flink run -z /default ./examples/batch/WordCount.jar --input /etc/resolv.conf `

Also you need to add to the flink-conf.yaml under the /flink-1.2.0 folder within the container the following settings:
 high-availability: zookeeper
 high-availability.zookeeper.quorum: master.mesos:2181
 high-availability.zookeeper.storageDir: hdfs://hdfs/flink/recovery


