### PR TITLE
Use ip-detect Script

### DIFF
--- a/container/appmaster/runit/service/flink/run
+++ b/container/appmaster/runit/service/flink/run
@@ -34,7 +34,7 @@ function add_if_non_empty() {
 }
 
 function add_mesos_configurations() {
-  add_if_non_empty jobmanager.rpc.address $(hostname -f)       
+  add_if_non_empty jobmanager.rpc.address $(bash /opt/mesosphere/bin/detect_ip)       
   add_if_non_empty mesos.resourcemanager.framework.role "${FLINK_DISPATCHER_MESOS_ROLE}"
   add_if_non_empty mesos.resourcemanager.framework.principal "${FLINK_DISPATCHER_MESOS_PRINCIPAL}"
   add_if_non_empty mesos.resourcemanager.framework.secret "${FLINK_DISPATCHER_MESOS_SECRET}"


### PR DESCRIPTION
This PR fixes a bug on AWS where using `hostname` command returns the `ip-<redacted>` hostname. This hostname may not resolve properly in some cases. Use the ip-detect script instead. 